### PR TITLE
stop sending TF updates when removing a cancelled goal

### DIFF
--- a/src/tf_web_republisher.cpp
+++ b/src/tf_web_republisher.cpp
@@ -113,6 +113,7 @@ public:
       if(info.handle == gh)
       {
         it = active_goals_.erase(it);
+        info.timer_.stop();
         info.handle.setCanceled();
         return;
       }


### PR DESCRIPTION
I was wondering why sending cancel requests to running tf2_web_republisher goals didn't seem to do anything - this was it :)
