### PR TITLE
Only log errors for the first exception on each source/target pair

### DIFF
--- a/include/tf_pair.h
+++ b/include/tf_pair.h
@@ -44,7 +44,11 @@ class TFPair
 public:
 
   TFPair() :
-       angular_thres_(0.0f), trans_thres_(0.0f), updated_(false), first_transmission_(true)
+    is_okay(true),
+    angular_thres_(0.0f),
+    trans_thres_(0.0f),
+    updated_(false),
+    first_transmission_(true)
   {
   }
 

--- a/include/tf_pair.h
+++ b/include/tf_pair.h
@@ -52,6 +52,7 @@ public:
          const std::string& target_frame,
          float angular_thres = 0.0f,
          float trans_thres = 0.0f) :
+      is_okay(true),
       source_frame_(source_frame),
       target_frame_(target_frame),
       angular_thres_(angular_thres),
@@ -146,7 +147,9 @@ public:
     return source_frame_+"-"+target_frame_;
   }
 
-
+public:
+  bool is_okay; //!< save whether this transform is okay, so we can print only a single message
+                //!< if a transform breaks/starts working again
 private:
   std::string source_frame_;
   std::string target_frame_;

--- a/src/tf_web_republisher.cpp
+++ b/src/tf_web_republisher.cpp
@@ -307,12 +307,29 @@ public:
                                                it->getSourceFrame(),
                                                ros::Time(0));
 
+        // If the transform broke earlier, but worked now (we didn't get
+        // booted into the catch block), tell the user all is well again
+        if (!it->is_okay)
+        {
+          it->is_okay = true;
+          ROS_INFO_STREAM("Transform from "
+                          << it->getSourceFrame()
+                          << " to "
+                          << it->getTargetFrame()
+                          << " is working again at time "
+                          << transform.header.stamp.toSec());
+        }
         // update tf_pair with transformtion
         it->updateTransform(transform);
       }
       catch (tf2::TransformException ex)
       {
-        ROS_ERROR("%s", ex.what());
+        // Only log an error if the transform was okay before
+        if (it->is_okay)
+        {
+          it->is_okay = false;
+          ROS_ERROR("%s", ex.what());
+        }
       }
 
       // check angular and translational thresholds


### PR DESCRIPTION
Running tf2_web_republisher with a large number of frames, ```output="screen"``` and a broken TF tree causes a flood of error messages that can actually hurt performance, not to mention legibility of any other log messages
This change makes it so that one error message per source/target pair is logged when the ```lookupTransform()``` fails for the first time, as well as an info message when it starts working again.

Another way to achieve similar results would be to use the ```ROS_ERROR_THROTTLE``` macro instead, but I think in most, if not all, cases, subsequent exceptions after the first are not going to be different or helpful.