### PR TITLE
Added dependency to message_generation and message_runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ generate_messages(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  CATKIN_DEPENDS tf tf2_ros geometry_msgs actionlib actionlib_msgs
+  CATKIN_DEPENDS tf tf2_ros geometry_msgs actionlib actionlib_msgs message_runtime
 )
 
 ###########

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tf2_web_republisher)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS tf tf2_ros geometry_msgs actionlib actionlib_msgs roscpp)
+find_package(catkin REQUIRED COMPONENTS tf tf2_ros geometry_msgs actionlib actionlib_msgs roscpp message_generation)
 find_package(Boost REQUIRED COMPONENTS thread)
 
 #######################################

--- a/package.xml
+++ b/package.xml
@@ -28,4 +28,5 @@
   <run_depend>roscpp</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>message_runtime</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>


### PR DESCRIPTION
I had to add this dependency for a ROS kinetic workspace with rosjava.

The thrown error was oddly specific:
 
    IOError: could not find tf2_web_republisher among message packages. Does the that package have a <build_depend> on message_generation in its package.xml?