### PR TITLE
Fix compilation with c++11

### DIFF
--- a/src/tf_web_republisher.cpp
+++ b/src/tf_web_republisher.cpp
@@ -134,7 +134,7 @@ public:
 
 
 
-  void cancelCB(GoalHandle& gh)
+  void cancelCB(GoalHandle gh)
   {
     boost::mutex::scoped_lock l(goals_mutex_);
 
@@ -192,7 +192,7 @@ public:
     }
   }
 
-  void goalCB(GoalHandle& gh)
+  void goalCB(GoalHandle gh)
   {
     ROS_DEBUG("GoalHandle request received");
 


### PR DESCRIPTION
Fixes #21 

This fixes compilation if C++11 is enabled (eg: you use gcc 6 or above)